### PR TITLE
Use real timing for calculating timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,4 +101,3 @@ ENV/
 .mypy_cache/
 
 snowboy
-README.rst

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![code-climate-image]][code-climate]
 [![circle-ci-image]][circle-ci]
 [![codecov-image]][codecov]
-[![gemnasium-image]][gemnasium]
 
 **Python library to manage the life-cycle of voice commands. Useful working with Alexa Voice Service.**
 
@@ -96,7 +95,7 @@ with wave.open('./tests/resources/alexa_what_time_is_it.wav', 'rb') as f:
     while f.tell() < f.getnframes():
         lifecycle.extend_audio(f.readframes(1024))
     # pad with silence at the end. See "Expecting slower or faster commands".
-    for i in range(lifecycle.timeout_manager.remaining_silent_frames + 1):
+    for i in range(lifecycle.timeout_manager.remaining_silent_seconds + 1):
         lifecycle.extend_audio(bytes([0, 0]*(1024*9)))
 ```
 
@@ -271,11 +270,11 @@ To avoid this the lifecycle tolerates some silence in the command before the lif
 
 To change this default behaviour `timeout_manager_class` can be changed. The available timeout managers are:
 
-| Timeout manager         | Notes                                            |
-| -------------------------| ------------------------------------------------ |
+| Timeout manager            | Notes                                            |
+| ---------------------------| ------------------------------------------------ |
 | `ShortTimeoutManager`      | Allows one second of silence.                    |
-| `MediumTimeoutManager`     | **default** Allows two seconds of silence.       |
-| `LongTimeoutManager`       | Allows tree seconds of silence                   |
+| `MediumTimeoutManager`     | **default** Allows 2 seconds of silence.         |
+| `LongTimeoutManager`       | Allows three seconds of silence.                 |
 
 To make a custom timeout manager create a subclass of `command_lifecycle.timeout.BaseTimeoutManager`:
 
@@ -287,7 +286,7 @@ from command_lifecycle import timeout, wakeword
 
 
 class MyCustomTimeoutManager(timeout.BaseTimeoutManager):
-    allowed_silent_frames = 40
+    allowed_silent_seconds = 4
 
 
 class AudioLifecycle(lifecycle.BaseAudioLifecycle):
@@ -304,6 +303,10 @@ pip install -r requirements-dev.txt
 ./scripts/tests.sh
 ```
 
+## Versioning
+
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [PyPI](https://pypi.org/project/command-lifecycle/#history).
+
 ## Other projects ##
 This library is used by [alexa-browser-client](https://github.com/richtier/alexa-browser-client), which allows you to talk to Alexa from your browser.
 
@@ -316,6 +319,3 @@ This library is used by [alexa-browser-client](https://github.com/richtier/alexa
 
 [codecov-image]: https://codecov.io/gh/richtier/voice-command-lifecycle/branch/master/graph/badge.svg
 [codecov]: https://codecov.io/gh/richtier/voice-command-lifecycle
-
-[gemnasium-image]: https://gemnasium.com/badges/github.com/richtier/voice-command-lifecycle.svg
-[gemnasium]: https://gemnasium.com/github.com/richtier/voice-command-lifecycle

--- a/command_lifecycle/lifecycle.py
+++ b/command_lifecycle/lifecycle.py
@@ -23,12 +23,11 @@ class BaseAudioLifecycle:
         self.audio_buffer.extend(wav_audio)
         if self.was_wakeword_uttered():
             self.handle_command_started()
+            self.timeout_manager.reset()
         elif self.has_command_finished():
             self.handle_command_finised()
         elif self.is_talking():
             self.timeout_manager.reset()
-        elif self.is_command_pending:
-            self.timeout_manager.increment()
 
     def is_talking(self) -> bool:
         return self.audio_detector.is_talking(self.audio_buffer)

--- a/command_lifecycle/timeout.py
+++ b/command_lifecycle/timeout.py
@@ -1,31 +1,34 @@
 import abc
+from datetime import datetime
 
 
 class BaseTimeoutManager(abc.ABC):
-    allowed_silent_frames = abc.abstractproperty()
-    elapsed_silent_frames = 0
-
-    def increment(self):
-        self.elapsed_silent_frames += 1
+    allowed_silent_seconds = abc.abstractproperty()
 
     def reset(self):
-        self.elapsed_silent_frames = 0
+        self.silence_started_time = datetime.utcnow()
 
     def has_timedout(self) -> bool:
-        return self.elapsed_silent_frames >= self.allowed_silent_frames
+        return self.remaining_silent_seconds <= 0
 
     @property
-    def remaining_silent_frames(self):
-        return self.allowed_silent_frames - self.elapsed_silent_frames
+    def elapsed_silent_seconds(self) -> int:
+        if self.silence_started_time is None:
+            raise ValueError('reset must be called before this method')
+        return (datetime.utcnow() - self.silence_started_time).total_seconds()
+
+    @property
+    def remaining_silent_seconds(self) -> int:
+        return self.allowed_silent_seconds - self.elapsed_silent_seconds
 
 
 class ShortTimeoutManager(BaseTimeoutManager):
-    allowed_silent_frames = 10
+    allowed_silent_seconds = 1
 
 
 class MediumTimeoutManager(BaseTimeoutManager):
-    allowed_silent_frames = 15
+    allowed_silent_seconds = 2
 
 
 class LongTimeoutManager(BaseTimeoutManager):
-    allowed_silent_frames = 20
+    allowed_silent_seconds = 3

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,0 +1,369 @@
+Voice Command Lifecycle
+=======================
+
+|code-climate-image| |circle-ci-image| |codecov-image|
+
+**Python library to manage the life-cycle of voice commands. Useful
+working with Alexa Voice Service.**
+
+--------------
+
+Installation
+------------
+
+.. code:: bash
+
+    pip install command_lifecycle
+
+Wakeword detector
+~~~~~~~~~~~~~~~~~
+
+A wakeword is a specific word that triggers the code to spring into
+action. It allows your code to be idle until the specific word is
+uttered.
+
+The audio lifecycle uses
+`snowboy <https://github.com/Kitt-AI/snowboy#compile-a-python-wrapper>`__
+to determine if the wakeword was uttered. The library will need to be
+installed first.
+
+Once you have compiled snowboy, copy the compiled ``snowboy`` folder to
+the top level of you project. By default, the folder structure should
+be:
+
+::
+
+    .
+    ├── ...
+    ├── snowboy
+    |   ├── snowboy-detect-swig.cc
+    |   ├── snowboydetect.py
+    |   └── resources
+    |       ├── alexa.umdl
+    |       └── common.res
+    └── ...
+
+If the default structure does not suit your needs can customize the
+`wakeword detector <#wakeword>`__.
+
+Usage
+-----
+
+You should send a steady stream of audio to to the lifecycle by
+repetitively calling ``lifecycle.extend_audio(some_audio_bytes)``. If
+the wakeword such as "Alexa" (default), or "ok, Google" was uttered then
+``handle_command_started`` is called. ``handle_command_finised`` is then
+called once the command audio that followed the wakeword has finished.
+
+Microphone audio
+~~~~~~~~~~~~~~~~
+
+.. code:: py
+
+    import pyaudio
+
+    import command_lifecycle
+
+
+    class AudioLifecycle(command_lifecycle.BaseAudioLifecycle):
+
+        def handle_command_started(self):
+            super().handle_command_started()
+            print('The audio contained the wakeword!')
+
+        def handle_command_finised(self):
+            super().handle_command_finised()
+            print('the command in the audio has finished')
+
+    lifecycle = AudioLifecycle()
+
+    p = pyaudio.PyAudio()
+    stream = p.open(format=pyaudio.paInt16, channels=1, rate=16000, input=True)
+
+    try:
+        print('listening. Start by saying "Alexa". Press CTRL + C to exit.')
+        while True:
+            lifecycle.extend_audio(stream.read(1024))
+    finally:
+        stream.stop_stream()
+        stream.close()
+        p.terminate()
+
+File audio
+~~~~~~~~~~
+
+.. code:: py
+
+    import wave
+
+    import command_lifecycle
+
+
+    class AudioLifecycle(command_lifecycle.BaseAudioLifecycle):
+        def handle_command_started(self):
+            super().handle_command_started()
+            print('The audio contained the wakeword!')
+
+        def handle_command_finised(self):
+            super().handle_command_finised()
+            print('the command in the audio has finished')
+
+
+    lifecycle = AudioLifecycle()
+    with wave.open('./tests/resources/alexa_what_time_is_it.wav', 'rb') as f:
+        while f.tell() < f.getnframes():
+            lifecycle.extend_audio(f.readframes(1024))
+        # pad with silence at the end. See "Expecting slower or faster commands".
+        for i in range(lifecycle.timeout_manager.remaining_silent_seconds + 1):
+            lifecycle.extend_audio(bytes([0, 0]*(1024*9)))
+
+Usage with Alexa
+~~~~~~~~~~~~~~~~
+
+``command_lifecycle`` is useful for interacting with voice services. The
+lifecycle waits until a wakeword was issued and then start streaming the
+audio command to the voice service (using `Alexa Voice Service
+Client <https://github.com/richtier/alexa-voice-service-client>`__),
+then do something useful with the response:
+
+.. code:: py
+
+    from avs_client.avs_client.client import AlexaVoiceServiceClient
+    import pyaudio
+
+    import command_lifecycle
+
+
+    class AudioLifecycle(command_lifecycle.BaseAudioLifecycle):
+        alexa_client = AlexaVoiceServiceClient(
+            client_id='my-client-id'
+            secret='my-secret',
+            refresh_token='my-refresh-token',
+        )
+
+        def __init__(self):
+            self.alexa_client.connect()
+            super().__init__()
+
+        def handle_command_started(self):
+            super().handle_command_started()
+            audio_file = command_lifecycle.to_audio_file()
+            alexa_response_audio = self.alexa_client.send_audio_file(audio_file)
+            if alexa_response_audio:
+                # do something with the AVS audio response, e.g., play it.
+
+    lifecycle = AudioLifecycle()
+
+    p = pyaudio.PyAudio()
+    stream = p.open(format=pyaudio.paInt16, channels=1, rate=16000, input=True)
+
+    try:
+        print('listening. Start by saying "Alexa". Press CTRL + C to exit.')
+        while True:
+            lifecycle.extend_audio(stream.read(1024))
+    finally:
+        stream.stop_stream()
+        stream.close()
+        p.terminate()
+
+Customization
+-------------
+
+Wakeword
+~~~~~~~~
+
+The default wakeword is "Alexa". This can be changed by sub-classing
+``command_lifecycle.wakeword.SnowboyWakewordDetector``:
+
+.. code:: py
+
+
+    from command_lifecycle import wakeword
+
+
+    class MySnowboyWakewordDetector(wakeword.SnowboyWakewordDetector):
+        decoder_models = [
+            {
+                'name': 'CUSTOM',
+                'model': b'path/to/custom-wakeword-model.umdl'
+                'sensitivity': b'0.5',
+            }
+        ]
+
+
+    class AudioLifecycle(lifecycle.BaseAudioLifecycle):
+        audio_detector_class = MySnowboyWakewordDetector
+
+        def handle_command_started(self):
+            super().handle_command_started()
+            print('The audio contained the wakeword!')
+
+        def handle_command_finised(self):
+            super().handle_command_finised()
+            print('the command in the audio has finished')
+
+
+    lifecycle = AudioLifecycle()
+    # now load the audio into lifecycle
+
+See the `Snowboy
+docs <https://github.com/Kitt-AI/snowboy#hotword-as-a-service>`__ for
+steps on creating custom wakeword models.
+
+Multiple Wakewords
+~~~~~~~~~~~~~~~~~~
+
+Triggering different behaviour for different wakeword may be desirable.
+To do this use multiple items in ``decoder_models``:
+
+.. code:: py
+
+    from command_lifecycle import wakeword
+
+
+    class MyMultipleWakewordDetector(wakeword.SnowboyWakewordDetector):
+        GOOGLE = 'GOOGLE'
+
+        decoder_models = wakeword.SnowboyWakewordDetector.decoder_models + [
+            {
+                'name': GOOGLE,
+                'model': b'path/to/okgoogle.umdl',
+                'sensitivity': b'0.5',
+            }
+        ]
+
+
+    class AudioLifecycle(lifecycle.BaseAudioLifecycle):
+        audio_detector_class = MyMultipleWakewordDetector
+
+        def handle_command_started(self):
+            name = self.audio_detector.get_uttered_wakeword_name(self.audio_buffer)
+            if name == self.audio_detector.ALEXA:
+                print('Alexa standing by')
+            elif name == self.audio_detector.GOOGLE:
+                print('Google at your service')
+            super().handle_command_started()
+
+You can download wakewords from
+`here <https://snowboy.kitt.ai/dashboard>`__.
+
+Wakeword detector
+~~~~~~~~~~~~~~~~~
+
+Snowboy is the default wakeword detector. Other wakeword detectors can
+be used by sub-classing
+``command_lifecycle.wakeword.BaseWakewordDetector`` and setting
+``wakeword_detector_class`` to your custom class:
+
+.. code:: py
+
+    import wave
+
+    from command_lifecycle import lifecycle, wakeword
+
+
+    class MyCustomWakewordDetector(wakeword.BaseWakewordDetector):
+        import_error_message = 'Cannot import wakeword library!'
+        wakeword_library_import_path = 'path.to.wakeword.Library'
+
+        def was_wakeword_uttered(self, buffer):
+            # use the library to check if the audio in the buffer has the wakeword.
+            # not `buffer.get()` returns the audio inside the buffer.
+            ...
+
+        def is_talking(self, buffer):
+            # use the library to check if the audio in the buffer has audible words
+            # not `buffer.get()` returns the audio inside the buffer.
+            ...
+
+
+    class AudioLifecycle(lifecycle.BaseAudioLifecycle):
+        audio_detector_class = MyCustomWakewordDetector
+
+        def handle_command_started(self):
+            super().handle_command_started()
+            print('The audio contained the wakeword!')
+
+        def handle_command_finised(self):
+            super().handle_command_finised()
+            print('the command in the audio has finished')
+
+
+    lifecycle = AudioLifecycle()
+    # now load the audio into lifecycle
+
+Expecting slower or faster commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The person giving the audio command might take a moment to collect their
+thoughts before finishing the command. This silence could be interpreted
+as the command ending, resulting in ``handle_command_finised`` being
+called prematurely.
+
+To avoid this the lifecycle tolerates some silence in the command before
+the lifecycle timesout the command. This silence can happen at the
+beginning or middle of the command. Note a side-effect of this is there
+will be a pause between when the person has stopped talking and when
+``handle_command_finised`` is called.
+
+To change this default behaviour ``timeout_manager_class`` can be
+changed. The available timeout managers are:
+
++----------------------------+--------------------------------------------+
+| Timeout manager            | Notes                                      |
++============================+============================================+
+| ``ShortTimeoutManager``    | Allows one second of silence.              |
++----------------------------+--------------------------------------------+
+| ``MediumTimeoutManager``   | **default** Allows 2 seconds of silence.   |
++----------------------------+--------------------------------------------+
+| ``LongTimeoutManager``     | Allows three seconds of silence.           |
++----------------------------+--------------------------------------------+
+
+To make a custom timeout manager create a subclass of
+``command_lifecycle.timeout.BaseTimeoutManager``:
+
+.. code:: py
+
+
+    import wave
+
+    from command_lifecycle import timeout, wakeword
+
+
+    class MyCustomTimeoutManager(timeout.BaseTimeoutManager):
+        allowed_silent_seconds = 4
+
+
+    class AudioLifecycle(lifecycle.BaseAudioLifecycle):
+        timeout_manager_class = MyCustomTimeoutManager
+
+Unit test
+---------
+
+To run the unit tests, call the following commands:
+
+.. code:: sh
+
+    pip install -r requirements-dev.txt
+    ./scripts/tests.sh
+
+Versioning
+----------
+
+We use `SemVer <http://semver.org/>`__ for versioning. For the versions
+available, see the
+`PyPI <https://pypi.org/project/command-lifecycle/#history>`__.
+
+Other projects
+--------------
+
+This library is used by
+`alexa-browser-client <https://github.com/richtier/alexa-browser-client>`__,
+which allows you to talk to Alexa from your browser.
+
+.. |code-climate-image| image:: https://codeclimate.com/github/richtier/voice-command-lifecycle/badges/gpa.svg
+   :target: https://codeclimate.com/github/richtier/voice-command-lifecycle
+.. |circle-ci-image| image:: https://circleci.com/gh/richtier/voice-command-lifecycle/tree/master.svg?style=svg
+   :target: https://circleci.com/gh/richtier/voice-command-lifecycle/tree/master
+.. |codecov-image| image:: https://codecov.io/gh/richtier/voice-command-lifecycle/branch/master/graph/badge.svg
+   :target: https://codecov.io/gh/richtier/voice-command-lifecycle

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
--r requirements.txt
 pytest==3.2.3
 pytest-cov==2.5.1
 pytest-sugar==0.9.0
 flake8==3.4.0
 codecov==2.0.9
 twine==1.9.1
+freezegun==0.3.9

--- a/scripts/publish-test.sh
+++ b/scripts/publish-test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 rm -rf build
 rm -rf dist
-pandoc --from=markdown --to=rst --output=README.rst README.md
+pandoc --from=markdown --to=rst --output=docs/README.rst README.md
 python setup.py bdist_wheel
 twine upload -r pypitest dist/*

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,3 +1,10 @@
 #!/bin/bash
 flake8 --exclude=.venv,venv,snowboy,build &&
-pytest --ignore=build --ignore=venv --ignore=.venv --cov=./ --cov-config=.coveragerc
+pytest \
+	--ignore=build \
+	--ignore=venv \
+	--ignore=.venv \
+	--cov=./ \
+	--cov-config=.coveragerc \
+	--last-failed \
+	--verbose

--- a/setup.py
+++ b/setup.py
@@ -1,29 +1,18 @@
 from setuptools import setup
 
-import pip.download
-from pip.req import parse_requirements
-
-
-def get_requirements():
-    requirements = parse_requirements(
-        'requirements.txt',
-        session=pip.download.PipSession()
-    )
-    return [str(r.req) for r in list(requirements)]
-
 
 setup(
     name='command_lifecycle',
     packages=['command_lifecycle'],
-    version='1.0.0',
+    version='2.0.0',
     url='https://github.com/richtier/voice-command-lifecycle',
     license='MIT',
     author='Richard Tier',
     author_email='rikatee@gmail.com',
     description='Python library to manage the life-cycle of voice commands.',
-    long_description=open('README.rst').read(),
+    long_description=open('docs/README.rst').read(),
     include_package_data=True,
-    install_requires=get_requirements(),
+    install_requires=[],
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,3 +1,4 @@
+import time
 from unittest.mock import call, Mock, patch
 import wave
 
@@ -175,9 +176,9 @@ def test_e2e_snowboy_snowboy_executes_callbacks(enable_snowboy, lifecycle):
     # finished not called yet: the command has not timedout yet
     assert lifecycle.handle_command_finised.call_count == 0
 
-    # pass in silence to trigger timeout
-    for i in range(lifecycle.timeout_manager.allowed_silent_frames+1):
-        lifecycle.extend_audio(bytes([0, 0]*(1024*10)))
+    # waiting for timeout then pass in long silence
+    time.sleep(lifecycle.timeout_manager_class.allowed_silent_seconds + 0.5)
+    lifecycle.extend_audio(bytes([0, 0]*(1024*10)))
 
     # timeout has now happened
     assert lifecycle.handle_command_finised.call_count == 1


### PR DESCRIPTION
The previous timeout logic was more-or-less "ok, there has been four calls to extend audio, thats too many. timeout".

Now it's more-or-less "ok, there has been two seconds of silence. thats too long".

The facilitates downstream projects that may be not calling `extend_audio` frequently.