### PR TITLE
Add converter for list of ints to bytes

### DIFF
--- a/command_lifecycle/timeout.py
+++ b/command_lifecycle/timeout.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 class BaseTimeoutManager(abc.ABC):
     allowed_silent_seconds = abc.abstractproperty()
+    silence_started_time = None
 
     def reset(self):
         self.silence_started_time = datetime.utcnow()

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='command_lifecycle',
     packages=['command_lifecycle'],
-    version='2.0.0',
+    version='2.1.0',
     url='https://github.com/richtier/voice-command-lifecycle',
     license='MIT',
     author='Richard Tier',

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -62,3 +62,10 @@ def test_lifecycle_filelike_length_expecting_audio():
     file_like = helpers.LifeCycleFileLike(audio_lifecycle)
 
     assert len(file_like) == 1025
+
+
+def test_wav_integer_samples_to_wav():
+    input_value = [1, 2, 3, 4, 5]
+    output_value = helpers.WavIntSamplestoWavConverter.convert(input_value)
+
+    assert output_value == b'\x01\x00\x02\x00\x03\x00\x04\x00\x05\x00'


### PR DESCRIPTION
Useful for upstream projects that stream audio from the browser but convert from floats (webaudio format) to integers client side, thus reducing the payload by approximately 90%.