### PR TITLE
Replace ticking timeout manager with threading timer

### DIFF
--- a/command_lifecycle/lifecycle.py
+++ b/command_lifecycle/lifecycle.py
@@ -14,19 +14,19 @@ class BaseAudioLifecycle:
     def __init__(self):
         self.audio_buffer = self.wakeword_audio_buffer_class()
         self.audio_detector = self.audio_detector_class()
-        self.timeout_manager = self.timeout_manager_class()
+        self.timeout_manager = self.timeout_manager_class(
+            function=self.handle_command_finised
+        )
 
     def extend_audio(self, input_audio):
         wav_audio = self.audio_converter_class.convert(input_audio)
         self.audio_buffer.extend(wav_audio)
-        wakeword_name = self.get_uttered_wakeword_name()
-        if wakeword_name:
-            self.handle_command_started(wakeword_name=wakeword_name)
+        if self.is_command_pending and self.is_talking():
             self.timeout_manager.reset()
-        elif self.has_command_finished():
-            self.handle_command_finised()
-        elif self.is_talking():
-            self.timeout_manager.reset()
+        else:
+            wakeword_name = self.get_uttered_wakeword_name()
+            if wakeword_name:
+                self.handle_command_started(wakeword_name=wakeword_name)
 
     def is_talking(self):
         return self.audio_detector.is_talking(self.audio_buffer)
@@ -34,18 +34,8 @@ class BaseAudioLifecycle:
     def get_uttered_wakeword_name(self):
         return self.audio_detector.get_uttered_wakeword_name(self.audio_buffer)
 
-    def has_timedout(self):
-        return self.timeout_manager.has_timedout()
-
-    def has_command_finished(self):
-        if not self.is_command_pending:
-            return False
-        # prevent prematurely finishing the command
-        # e.g., user is thinking briefly, or there is pause between wakeword
-        # being uttered and the command being said.
-        return not self.is_talking() and self.has_timedout()
-
     def handle_command_started(self, wakeword_name):
+        self.timeout_manager.reset(start=True)
         self.is_command_pending = True
         self.audio_buffer = self.command_audio_buffer_class()
 

--- a/command_lifecycle/timeout.py
+++ b/command_lifecycle/timeout.py
@@ -1,26 +1,17 @@
 import abc
-from datetime import datetime
+
+from resettabletimer import ResettableTimer
 
 
-class BaseTimeoutManager(abc.ABC):
-    allowed_silent_seconds = abc.abstractproperty()
-    silence_started_time = None
-
-    def reset(self):
-        self.silence_started_time = datetime.utcnow()
-
-    def has_timedout(self):
-        return self.remaining_silent_seconds <= 0
+class BaseTimeoutManager(abc.ABC, ResettableTimer):
 
     @property
-    def elapsed_silent_seconds(self):
-        if self.silence_started_time is None:
-            raise ValueError('reset must be called before this method')
-        return (datetime.utcnow() - self.silence_started_time).total_seconds()
+    @abc.abstractmethod
+    def allowed_silent_seconds(self):
+        return 0
 
-    @property
-    def remaining_silent_seconds(self):
-        return self.allowed_silent_seconds - self.elapsed_silent_seconds
+    def __init__(self, function):
+        super().__init__(time=self.allowed_silent_seconds, function=function)
 
 
 class ShortTimeoutManager(BaseTimeoutManager):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 setup(
     name='command_lifecycle',
     packages=['command_lifecycle'],
-    version='4.0.0',
+    version='4.1.0',
     url='https://github.com/richtier/voice-command-lifecycle',
     license='MIT',
     author='Richard Tier',
@@ -13,7 +13,9 @@ setup(
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
     include_package_data=True,
-    install_requires=[],
+    install_requires=[
+        'resettabletimer>=0.6.3,<1.0.0',
+    ],
     extras_require={
         'test': [
             'pytest==3.2.3',
@@ -21,7 +23,6 @@ setup(
             'pytest-sugar==0.9.0',
             'flake8==3.4.0',
             'codecov==2.0.9',
-            'freezegun==0.3.9',
             'twine>=1.11.0,<2.0.0',
             'wheel>=0.31.0,<1.0.0',
             'setuptools>=38.6.0,<39.0.0',
@@ -34,7 +35,7 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],

--- a/tests/test_timeout.py
+++ b/tests/test_timeout.py
@@ -1,6 +1,5 @@
-from datetime import datetime, timedelta
+from unittest import mock
 
-from freezegun import freeze_time
 import pytest
 
 from command_lifecycle import timeout
@@ -11,8 +10,13 @@ class SimpleTimeoutManager(timeout.BaseTimeoutManager):
 
 
 @pytest.fixture
-def manager():
-    return SimpleTimeoutManager()
+def timeout_callback():
+    return mock.Mock()
+
+
+@pytest.fixture
+def manager(timeout_callback):
+    return SimpleTimeoutManager(timeout_callback)
 
 
 def test_missing_timeout_seconds_subclass():
@@ -31,47 +35,3 @@ def test_allowed_silent_seconds():
     assert timeout.ShortTimeoutManager.allowed_silent_seconds == 1
     assert timeout.MediumTimeoutManager.allowed_silent_seconds == 2
     assert timeout.LongTimeoutManager.allowed_silent_seconds == 3
-
-
-def test_reset(manager):
-    silence_started_time = datetime.utcnow() - timedelta(seconds=1)
-    manager.silence_started_time = silence_started_time
-
-    assert manager.silence_started_time == silence_started_time
-
-    expected = datetime(2012, 1, 14, 3, 21, 34)
-    with freeze_time(expected):
-        manager.reset()
-
-    assert manager.silence_started_time == expected
-
-
-@freeze_time(datetime(2012, 1, 14, 3, 21, 34))
-@pytest.mark.parametrize('allowed,elapsed,expected', [
-    [5, 0, False],
-    [5, 4, False],
-    [5, 5, True],
-    [5, 6, True],
-])
-def test_has_timedout(manager, allowed, elapsed, expected):
-    manager.allowed_silent_seconds = allowed
-    manager.silence_started_time = (
-        datetime.utcnow() - timedelta(seconds=elapsed)
-    )
-    assert manager.has_timedout() is expected
-
-
-@freeze_time(datetime(2012, 1, 14, 3, 21, 34))
-@pytest.mark.parametrize('allowed,elapsed,expected', [
-    [5, 0, 5],
-    [5, 4, 1],
-    [5, 5, 0],
-    [5, 6, -1],
-])
-def test_remaining_silent_seconds(manager, allowed, elapsed, expected):
-    manager.allowed_silent_seconds = allowed
-    manager.silence_started_time = (
-        datetime.utcnow() - timedelta(seconds=elapsed)
-    )
-
-    assert manager.remaining_silent_seconds == expected


### PR DESCRIPTION
* Allows for upstream projects to not stream silence to the server and still have timeout manager do it's job.
* Prevents wakeword from triggering command if currently in a command

